### PR TITLE
Switch to v2 installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-LIBRARY_VERSION=`cat library/setup.py | grep version | awk -F"'" '{print $$2}'`
-LIBRARY_NAME=`cat library/setup.py | grep name | awk -F"'" '{print $$2}'`
+LIBRARY_VERSION=$(shell grep version library/setup.cfg | awk -F" = " '{print $$2}')
+LIBRARY_NAME=$(shell grep name library/setup.cfg | awk -F" = " '{print $$2}')
 
 .PHONY: usage install uninstall
 usage:
+	@echo "Library: ${LIBRARY_NAME}"
+	@echo "Version: ${LIBRARY_VERSION}\n"
 	@echo "Usage: make <target>, where target is one of:\n"
 	@echo "install:       install the library locally from source"
 	@echo "uninstall:     uninstall the local library"
@@ -13,6 +15,7 @@ usage:
 	@echo "python-clean:  clean python build and dist directories"
 	@echo "python-dist:   build all python distribution files"
 	@echo "python-testdeploy: build all and deploy to test PyPi"
+	@echo "tag:           tag the repository with the current version"
 
 install:
 	./install.sh
@@ -22,20 +25,25 @@ uninstall:
 
 check:
 	@echo "Checking for trailing whitespace"
-	@! grep -IUrn --color "[[:blank:]]$$" --exclude-dir=.tox --exclude-dir=.git --exclude=PKG-INFO
+	@! grep -IUrn --color "[[:blank:]]$$" --exclude-dir=sphinx --exclude-dir=.tox --exclude-dir=.git --exclude=PKG-INFO
 	@echo "Checking for DOS line-endings"
-	@! grep -IUrn --color "" --exclude-dir=fonts --exclude-dir=.tox --exclude-dir=.git --exclude=Makefile
+	@! grep -IUrn --color "" --exclude-dir=sphinx --exclude-dir=.tox --exclude-dir=.git --exclude=Makefile
 	@echo "Checking library/CHANGELOG.txt"
 	@cat library/CHANGELOG.txt | grep ^${LIBRARY_VERSION}
 	@echo "Checking library/${LIBRARY_NAME}/__init__.py"
 	@cat library/${LIBRARY_NAME}/__init__.py | grep "^__version__ = '${LIBRARY_VERSION}'"
 
+tag:
+	git tag -a "v${LIBRARY_VERSION}" -m "Version ${LIBRARY_VERSION}"
+
 python-readme: library/README.rst
 
 python-license: library/LICENSE.txt
 
-library/README.rst: README.md
+library/README.rst: README.md library/CHANGELOG.txt
 	pandoc --from=markdown --to=rst -o library/README.rst README.md
+	echo "" >> library/README.rst
+	cat library/CHANGELOG.txt >> library/README.rst
 
 library/LICENSE.txt: LICENSE
 	cp LICENSE library/LICENSE.txt

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Designed for environmental monitoring, Enviro+ lets you measure air quality (pol
 
 # Installing
 
-You're best using the git clone / install.sh method if you want all of the UART serial configuration for the PMS5003 particulate matter sensor to run automatically.
+You're best using the "One-line" install method if you want all of the UART serial configuration for the PMS5003 particulate matter sensor to run automatically.
 
 ## One-line (Installs from GitHub)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Enviro+ pHAT
+# Enviro+
+
+Designed for environmental monitoring, Enviro+ lets you measure air quality (pollutant gases and particulates), temperature, pressure, humidity, light, and noise level. Learn more - https://shop.pimoroni.com/products/enviro-plus
 
 [![Build Status](https://travis-ci.com/pimoroni/enviroplus-python.svg?branch=master)](https://travis-ci.com/pimoroni/enviroplus-python)
 [![Coverage Status](https://coveralls.io/repos/github/pimoroni/enviroplus-python/badge.svg?branch=master)](https://coveralls.io/github/pimoroni/enviroplus-python?branch=master)
@@ -45,3 +47,9 @@ And install additional dependencies:
 ```
 sudo apt install python-numpy python-smbus
 ```
+
+## Help & Support
+
+* GPIO Pinout - https://pinout.xyz/pinout/enviro_plus
+* Support forums - http://forums.pimoroni.com/c/support
+* Discord - https://discord.gg/hr93ByC

--- a/README.md
+++ b/README.md
@@ -7,15 +7,41 @@
 
 # Installing
 
-Stable library from PyPi:
+You're best using the git clone / install.sh method if you want all of the UART serial configuration for the PMS5003 particulate matter sensor to run automatically.
 
-* Just run `sudo pip install enviroplus`
+## One-line (Installs from GitHub)
 
-(**Note** that you're best using the git clone / install.sh method below if you want all of the UART serial configuration for the PMS5003 particulate matter sensor to run automatically)
+```
+curl -sSL https://get.pimoroni.com/enviroplus | bash
+```
 
-Latest/development library from GitHub:
+**Note** report issues with one-line installer here: https://github.com/pimoroni/get
+
+## Or... Install and configure dependencies from GitHub:
 
 * `git clone https://github.com/pimoroni/enviroplus-python`
 * `cd enviroplus-python`
 * `sudo ./install.sh`
 
+**Note** Raspbian Lite users may first need to install git: `sudo apt install git`
+
+## Or... Install from PyPi and configure manually:
+
+* Run `sudo pip install enviroplus`
+
+**Note** this wont perform any of the required configuration changes on your Pi, you may additionally need to:
+
+* Enable i2c: `raspi-config nonint do_i2c 0`
+* Enable SPI: `raspi-config nonint do_spi 0`
+
+And if you're using a PMS5003 sensor you will need to:
+
+* Enable serial: `raspi-config nonint set_config_var enable_uart 1 /boot/config.txt`
+* Disable serial terminal: `sudo raspi-config nonint do_serial 1`
+* Add `dtoverlay=pi3-miniuart-bt` to your `/boot/config.txt`
+
+And install additional dependencies:
+
+```
+sudo apt install python-numpy python-smbus
+```

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ fi
 function do_config_backup {
 	if [ ! $CONFIG_BACKUP == true ]; then
 		CONFIG_BACKUP=true
-		FILENAME="config.preinstall-$LIBRARY_NAME-$DATESTAMP.txt"
+		FILENAME="/boot/config.preinstall-$LIBRARY_NAME-$DATESTAMP.txt"
 		printf "Backing up $CONFIG to $FILENAME\n"
 		cp $CONFIG $FILENAME
 	fi

--- a/library/README.rst
+++ b/library/README.rst
@@ -1,7 +1,11 @@
 Enviro+ pHAT
 ============
 
-|Build Status| |Coverage Status| |PyPi Package| |Python Versions|
+`Build Status <https://travis-ci.com/pimoroni/enviroplus-python>`__
+`Coverage
+Status <https://coveralls.io/github/pimoroni/enviroplus-python?branch=master>`__
+`PyPi Package <https://pypi.python.org/pypi/enviroplus>`__ `Python
+Versions <https://pypi.python.org/pypi/enviroplus>`__
 
 Installing
 ==========
@@ -10,7 +14,7 @@ Stable library from PyPi:
 
 -  Just run ``sudo pip install enviroplus``
 
-(**Note** that you're best using the git clone / install.sh method below
+(**Note** that you’re best using the git clone / install.sh method below
 if you want all of the UART serial configuration for the PMS5003
 particulate matter sensor to run automatically)
 
@@ -20,11 +24,7 @@ Latest/development library from GitHub:
 -  ``cd enviroplus-python``
 -  ``sudo ./install.sh``
 
-.. |Build Status| image:: https://travis-ci.com/pimoroni/enviroplus-python.svg?branch=master
-   :target: https://travis-ci.com/pimoroni/enviroplus-python
-.. |Coverage Status| image:: https://coveralls.io/repos/github/pimoroni/enviroplus-python/badge.svg?branch=master
-   :target: https://coveralls.io/github/pimoroni/enviroplus-python?branch=master
-.. |PyPi Package| image:: https://img.shields.io/pypi/v/enviroplus.svg
-   :target: https://pypi.python.org/pypi/enviroplus
-.. |Python Versions| image:: https://img.shields.io/pypi/pyversions/enviroplus.svg
-   :target: https://pypi.python.org/pypi/enviroplus
+0.0.1
+-----
+
+* Initial Release

--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -39,7 +39,11 @@ ignore =
 
 [pimoroni]
 py2deps =
+	python-numpy
+	python-smbus
 py3deps =
+	python3-numpy
+	python3-smbus
 configtxt =
 	dtoverlay=pi3-miniuart-bt # for Enviro+
 commands =

--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -1,7 +1,30 @@
+# -*- coding: utf-8 -*-
 [metadata]
+name = enviroplus
+version = 0.0.1
+author = Philip Howard
+author_email = phil@pimoroni.com
+description = Enviro pHAT Plus environmental monitoring add-on for Raspberry Pi"
+long_description = file: README.rst
+keywords = Raspberry Pi
+url = https://www.pimoroni.com
+project_urls =
+	GitHub=https://www.github.com/pimoroni/enviroplus-python
+license = MIT
 # This includes the license file(s) in the wheel.
 # https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
 license_files = LICENSE.txt
+classifiers =
+	Development Status :: 4 - Beta
+	Operating System :: POSIX :: Linux
+	License :: OSI Approved :: MIT License
+	Intended Audience :: Developers
+	Programming Language :: Python :: 2.6
+	Programming Language :: Python :: 2.7
+	Programming Language :: Python :: 3
+	Topic :: Software Development
+	Topic :: Software Development :: Libraries
+	Topic :: System :: Hardware
 
 [flake8]
 exclude =
@@ -13,3 +36,16 @@ exclude =
 	dist
 ignore =
 	E501
+
+[pimoroni]
+py2deps =
+py3deps =
+configtxt =
+	dtoverlay=pi3-miniuart-bt # for Enviro+
+commands =
+	printf "Setting up i2c and SPI..\n"
+	raspi-config nonint do_spi 0
+	raspi-config nonint do_i2c 0
+	printf "Setting up serial for PMS5003..\n"
+	raspi-config nonint do_serial 1 				# Disable serial terminal over /dev/ttyAMA0
+	raspi-config nonint set_config_var enable_uart 1 $CONFIG	# Enable serial port

--- a/library/setup.py
+++ b/library/setup.py
@@ -22,33 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
-
-classifiers = ['Development Status :: 4 - Beta',
-               'Operating System :: POSIX :: Linux',
-               'License :: OSI Approved :: MIT License',
-               'Intended Audience :: Developers',
-               'Programming Language :: Python :: 2.6',
-               'Programming Language :: Python :: 2.7',
-               'Programming Language :: Python :: 3',
-               'Topic :: Software Development',
-               'Topic :: System :: Hardware']
+from setuptools import setup
 
 setup(
-    name='enviroplus',
-    version='0.0.1',
-    author='Philip Howard',
-    author_email='phil@pimoroni.com',
-    description="""Enviro pHAT Plus environmental monitoring add-on for Raspberry Pi""",
-    long_description=open('README.rst').read() + '\n' + open('CHANGELOG.txt').read(),
-    license='MIT',
-    keywords='Raspberry Pi',
-    url='http://www.pimoroni.com',
-    project_urls={'GitHub': 'https://www.github.com/pimoroni/enviroplus-python'},
-    classifiers=classifiers,
     packages=['enviroplus'],
     install_requires=['pimoroni-bme280', 'pms5003', 'ltr559', 'st7735', 'ads1015']
 )

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-LIBRARY_VERSION=`cat library/setup.py | grep version | awk -F"'" '{print $2}'`
-LIBRARY_NAME=`cat library/setup.py | grep name | awk -F"'" '{print $2}'`
+LIBRARY_VERSION=`cat library/setup.cfg | grep version | awk -F" = " '{print $2}'`
+LIBRARY_NAME=`cat library/setup.cfg | grep name | awk -F" = " '{print $2}'`
 
 printf "$LIBRARY_NAME $LIBRARY_VERSION Python Library: Uninstaller\n\n"
 
@@ -28,6 +28,6 @@ raspi-config nonint do_serial 0
 # Disable serial port
 raspi-config nonint set_config_var enable_uart 0 /boot/config.txt
 # Switch serial port back to miniUART
-sed -i 's/^dtoverlay=pi3-miniuart-bt/#dtoverlay=pi3-miniuart-bt/' /boot/config.txt
+sed -i 's/^dtoverlay=pi3-miniuart-bt # for Enviro+/#dtoverlay=pi3-miniuart-bt # for Enviro+/' /boot/config.txt
 
 printf "Done!\n"


### PR DESCRIPTION
This PR migrates Enviro+ Python to the new `setup.cfg` approach from  our boilerplate.

Additionally it uses the new `install.sh` which parses `setup.cfg` for dependencies and postinstall commands, intelligently backs up `/boot/config.txt` and lays the groundwork for a more managble installer infrastructure to be hooked by very minimal get.pimoroni.com scripts.