### PR TITLE
Add support for breakout ADC channel

### DIFF
--- a/examples/adc.py
+++ b/examples/adc.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import time
+from enviroplus import gas
+
+print("""adc.py - Print readings from the MICS6814 Gas sensor.
+
+Press Ctrl+C to exit!
+
+""")
+
+gas.enable_adc()
+gas.set_adc_gain(4.096)
+
+try:
+    while True:
+        readings = gas.read_all()
+        print(readings)
+        time.sleep(1.0)
+except KeyboardInterrupt:
+    pass

--- a/library/enviroplus/gas.py
+++ b/library/enviroplus/gas.py
@@ -6,7 +6,7 @@ import ads1015
 import RPi.GPIO as GPIO
 
 MICS6814_HEATER_PIN = 24
-MICS6814_GAIN = 6.148
+MICS6814_GAIN = 6.144
 
 ads1015.I2C_ADDRESS_DEFAULT = ads1015.I2C_ADDRESS_ALTERNATE
 _is_setup = False
@@ -132,3 +132,9 @@ def read_nh3():
     """Return gas resistance for nh3/ammonia"""
     setup()
     return read_all().nh3
+
+
+def read_adc():
+    """Return spare ADC channel value"""
+    setup()
+    return read_all().adc

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -16,6 +16,7 @@ def test_gas_setup():
     smbus.SMBus = SMBusFakeDevice
     sys.modules['smbus'] = smbus
     from enviroplus import gas
+    gas._is_setup = False
     gas.setup()
     gas.setup()
 
@@ -27,6 +28,7 @@ def test_gas_read_all():
     smbus.SMBus = SMBusFakeDevice
     sys.modules['smbus'] = smbus
     from enviroplus import gas
+    gas._is_setup = False
     result = gas.read_all()
 
     assert type(result.oxidising) == float
@@ -48,7 +50,49 @@ def test_gas_read_each():
     smbus.SMBus = SMBusFakeDevice
     sys.modules['smbus'] = smbus
     from enviroplus import gas
+    gas._is_setup = False
 
     assert int(gas.read_oxidising()) == 16641
     assert int(gas.read_reducing()) == 16727
     assert int(gas.read_nh3()) == 16813
+
+
+def test_gas_read_adc():
+    sys.modules['RPi'] = mock.Mock()
+    sys.modules['RPi.GPIO'] = mock.Mock()
+    smbus = mock.Mock()
+    smbus.SMBus = SMBusFakeDevice
+    sys.modules['smbus'] = smbus
+    from enviroplus import gas
+    gas._is_setup = False
+
+    gas.enable_adc(True)
+    gas.set_adc_gain(2.048)
+    assert gas.read_adc() == 0.255
+
+
+def test_gas_read_adc_default_gain():
+    sys.modules['RPi'] = mock.Mock()
+    sys.modules['RPi.GPIO'] = mock.Mock()
+    smbus = mock.Mock()
+    smbus.SMBus = SMBusFakeDevice
+    sys.modules['smbus'] = smbus
+    from enviroplus import gas
+    gas._is_setup = False
+
+    gas.enable_adc(True)
+    assert gas.read_adc() == 0.255
+
+
+def test_gas_read_adc_str():
+    sys.modules['RPi'] = mock.Mock()
+    sys.modules['RPi.GPIO'] = mock.Mock()
+    smbus = mock.Mock()
+    smbus.SMBus = SMBusFakeDevice
+    sys.modules['smbus'] = smbus
+    from enviroplus import gas
+    gas._is_setup = False
+
+    gas.enable_adc(True)
+    gas.set_adc_gain(2.048)
+    assert 'ADC' in str(gas.read_all())


### PR DESCRIPTION
Since the `gas` module is the one that initialises and uses the ADC, I've added the ability to configure the gain for, and optionally enable the spare ADC channel so that it can easily be used to read- for example- an analog CO2 sensor.

The new example `adc.py` demonstrates how to use it and the gain can be set to 6.144v, 4.096v, 2.094v, 1.024v, 0.512v or 0.256v to suit a range of sensor types with the best available resolution.