### PR TITLE
Improvements for #28 (Temperature compensation without sub process)

### DIFF
--- a/examples/all-in-one-no-pm.py
+++ b/examples/all-in-one-no-pm.py
@@ -14,7 +14,6 @@ except ImportError:
 
 from bme280 import BME280
 from enviroplus import gas
-from subprocess import PIPE, Popen
 from PIL import Image
 from PIL import ImageDraw
 from PIL import ImageFont
@@ -91,9 +90,10 @@ def display_text(variable, data, unit):
 
 # Get the temperature of the CPU for compensation
 def get_cpu_temperature():
-    process = Popen(['vcgencmd', 'measure_temp'], stdout=PIPE, universal_newlines=True)
-    output, _error = process.communicate()
-    return float(output[output.index('=') + 1:output.rindex("'")])
+    with open("/sys/class/thermal/thermal_zone0/temp", "r") as f:
+        temp = f.read()
+        temp = int(temp) / 1000.0
+    return temp
 
 
 # Tuning factor for compensation. Decrease this number to adjust the

--- a/examples/all-in-one.py
+++ b/examples/all-in-one.py
@@ -15,7 +15,6 @@ except ImportError:
 from bme280 import BME280
 from pms5003 import PMS5003, ReadTimeoutError as pmsReadTimeoutError
 from enviroplus import gas
-from subprocess import PIPE, Popen
 from PIL import Image
 from PIL import ImageDraw
 from PIL import ImageFont
@@ -96,9 +95,10 @@ def display_text(variable, data, unit):
 
 # Get the temperature of the CPU for compensation
 def get_cpu_temperature():
-    process = Popen(['vcgencmd', 'measure_temp'], stdout=PIPE, universal_newlines=True)
-    output, _error = process.communicate()
-    return float(output[output.index('=') + 1:output.rindex("'")])
+    with open("/sys/class/thermal/thermal_zone0/temp", "r") as f:
+        temp = f.read()
+        temp = int(temp) / 1000.0
+    return temp
 
 
 # Tuning factor for compensation. Decrease this number to adjust the

--- a/examples/luftdaten.py
+++ b/examples/luftdaten.py
@@ -71,11 +71,12 @@ def read_values():
     return values
 
 
-# Get CPU temperature to use for compensation
+# Get the temperature of the CPU for compensation
 def get_cpu_temperature():
-    process = Popen(['vcgencmd', 'measure_temp'], stdout=PIPE, universal_newlines=True)
-    output, _error = process.communicate()
-    return float(output[output.index('=') + 1:output.rindex("'")])
+    with open("/sys/class/thermal/thermal_zone0/temp", "r") as f:
+        temp = f.read()
+        temp = int(temp) / 1000.0
+    return temp
 
 
 # Get Raspberry Pi serial number to use as ID


### PR DESCRIPTION
After tweaking `compensate-temperature.py` it struck me that arbitrarily changing the source of temperature compensation may adversely affect long term readfings where the user updates their code.

This PR should fix the remaining instances of using a `vcgencmd measure_temp` subprocess in lieu of just reading the appropriate filesystem node, but we should probably merge it cautiously.  FAO @sandyjmacdonald 