### PR TITLE
Fixed graphing problem for PMS5003 results

### DIFF
--- a/examples/all-in-one.py
+++ b/examples/all-in-one.py
@@ -201,7 +201,7 @@ try:
             except pmsReadTimeoutError:
                 logging.warn("Failed to read PMS5003")
             else:
-                data = data.pm_ug_per_m3(1.0)
+                data = float(data.pm_ug_per_m3(1.0))
                 display_text(variables[mode], data, unit)
 
         if mode == 8:
@@ -212,7 +212,7 @@ try:
             except pmsReadTimeoutError:
                 logging.warn("Failed to read PMS5003")
             else:
-                data = data.pm_ug_per_m3(2.5)
+                data = float(data.pm_ug_per_m3(2.5))
                 display_text(variables[mode], data, unit)
 
         if mode == 9:
@@ -223,7 +223,7 @@ try:
             except pmsReadTimeoutError:
                 logging.warn("Failed to read PMS5003")
             else:
-                data = data.pm_ug_per_m3(10)
+                data = float(data.pm_ug_per_m3(10))
                 display_text(variables[mode], data, unit)
 
 # Exit cleanly


### PR DESCRIPTION
The PMS5003 library returns integers as sensor readings. This causes the current formula for colour scaling of the graph to not work properly because of integer division instead of float division. Converting the PMS5003 results from int to float solves the problem.

Before:
![Graphing before fix](https://user-images.githubusercontent.com/634992/67619471-cf1f3f80-f804-11e9-90fc-3fdb0e668566.jpg)

After:
![Graphing after fix](https://user-images.githubusercontent.com/634992/67619478-e0684c00-f804-11e9-99dd-4e0dbd583d61.jpg)

