### PR TITLE
Fixed Bluetooth breaking on Raspbian Stretch and Buster

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ And if you're using a PMS5003 sensor you will need to:
 * Enable serial: `raspi-config nonint set_config_var enable_uart 1 /boot/config.txt`
 * Disable serial terminal: `sudo raspi-config nonint do_serial 1`
 * Add `dtoverlay=pi3-miniuart-bt` to your `/boot/config.txt`
+* Add `core_freq=250` to your `/boot/config.txt`
+* Add `core_freq_min=250` to your `/boot/config.txt`
 
 And install additional dependencies:
 

--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -58,6 +58,8 @@ py3deps =
 	python3-pil
 configtxt =
 	dtoverlay=pi3-miniuart-bt
+	core_freq=250
+	core_freq_min=250
 commands =
 	printf "Setting up i2c and SPI..\n"
 	raspi-config nonint do_spi 0


### PR DESCRIPTION
Adding dtoverlay=pi3-miniuart-bt to /boot/config.txt without anything else breaks all Bluetooth functionality on Raspberry Pi models with a Bluetooth chip. Setting core_freq=250 and core_freq_min=250 fixes the problem.

p3-miniuart-bt has been renamed to miniuart-bt but the previous name was kept as an alias for compatibility reasons.

More info on miniuart-bt:
https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README#L1571