### PR TITLE
Remove inappropriate sleep between reads

### DIFF
--- a/examples/particulates.py
+++ b/examples/particulates.py
@@ -23,7 +23,6 @@ try:
         try:
             readings = pms5003.read()
             logging.info(readings)
-            time.sleep(1.0)
         except ReadTimeoutError:
             pms5003 = PMS5003()
 except KeyboardInterrupt:


### PR DESCRIPTION
The PMS5003 seems to buffer unread samples. If you are reading at a lower rate than it takes readings, then a progressively larger delay will occur between changes in actual PM levels and indicated PM levels. 

To see the issue:
1) run this example with the `time.sleep(1)` **included**
2) wait a few minutes
3) burn a piece of paper near the sensor and wait for the reported PM levels to spike

With the sleep included, there is a delay between introducing smoke and seeing reported levels rise (often a few minutes or longer, and can be hours if it has been running for some time). With the sleep removed you will see reported levels update almost immediately.

The correct way to use the sensor is to read as fast as the sensor allows, and not make any assumptions about what rate samples will be published at