### PR TITLE
Sleep before first PMS5003 reading

### DIFF
--- a/examples/combined.py
+++ b/examples/combined.py
@@ -37,6 +37,7 @@ bme280 = BME280()
 
 # PMS5003 particulate sensor
 pms5003 = PMS5003()
+time.sleep(1.0)
 
 # Create ST7735 LCD display class
 st7735 = ST7735.ST7735(


### PR DESCRIPTION
`PMS5003` will throw `ReadTimeoutError`s forever if we don't sleep for some arbitrary time before reading it for the first time.

One second seems to be enough, and that is in line with the value in [examples/particulates.py](https://github.com/pimoroni/enviroplus-python/blob/02c9f287f5963f5221b23fb05c2925eb261ca2de/examples/particulates.py#L19)