### PR TITLE
Fix launch bug in all-in-one-no-pm.py

### DIFF
--- a/examples/all-in-one-no-pm.py
+++ b/examples/all-in-one-no-pm.py
@@ -54,7 +54,7 @@ img = Image.new('RGB', (WIDTH, HEIGHT), color=(0, 0, 0))
 draw = ImageDraw.Draw(img)
 path = os.path.dirname(os.path.realpath(__file__))
 font_size = 20
-font = ImageFont.truetype(UserFont, FontSize)
+font = ImageFont.truetype(UserFont, font_size)
 
 message = ""
 


### PR DESCRIPTION
Launching all-in-one-no-pm.py results in an error due to line 57. FontSize should be replaced with the variable font_size, to run line 57 without error.