### PR TITLE
Catch #61 with tests and fix

### DIFF
--- a/library/enviroplus/noise.py
+++ b/library/enviroplus/noise.py
@@ -76,7 +76,7 @@ class Noise():
         amp_low = numpy.mean(magnitude[noise_floor:mid_start])
         amp_mid = numpy.mean(magnitude[mid_start:high_start])
         amp_high = numpy.mean(magnitude[high_start:noise_ceiling])
-        amp_total = (low + mid + high) / 3.0
+        amp_total = (amp_low + amp_mid + amp_high) / 3.0
 
         return amp_low, amp_mid, amp_high, amp_total
 

--- a/library/tests/conftest.py
+++ b/library/tests/conftest.py
@@ -14,6 +14,23 @@ class SMBusFakeDevice(MockSMBus):
         self.regs[0x00:0x01] = 0x0f, 0x00
 
 
+@pytest.fixture(scope='function', autouse=True)
+def cleanup():
+    yield None
+    try:
+        del sys.modules['enviroplus']
+    except KeyError:
+        pass
+    try:
+        del sys.modules['enviroplus.noise']
+    except KeyError:
+        pass
+    try:
+        del sys.modules['enviroplus.gas']
+    except KeyError:
+        pass
+
+
 @pytest.fixture(scope='function', autouse=False)
 def GPIO():
     """Mock RPi.GPIO module."""

--- a/library/tests/test_noise.py
+++ b/library/tests/test_noise.py
@@ -1,32 +1,7 @@
-import sys
-import mock
 import pytest
 
 
-def force_reimport(module):
-    """Force the module under test to be re-imported.
-
-    Because pytest runs all tests within the same scope (this makes me cry)
-    we have to do some manual housekeeping to avoid tests polluting each other.
-
-    Since conftest.py already does some sys.modules mangling I see no reason not to
-    do the same thing here.
-    """
-    if "." in module:
-        steps = module.split(".")
-    else:
-        steps = [module]
-    
-    for i in range(len(steps)):
-        module = ".".join(steps[0:i + 1])
-        try:
-            del sys.modules[module]
-        except KeyError:
-            pass
-
-
 def test_noise_setup(sounddevice, numpy):
-    force_reimport('enviroplus.noise')
     from enviroplus.noise import Noise
 
     noise = Noise(sample_rate=16000, duration=0.1)
@@ -34,9 +9,6 @@ def test_noise_setup(sounddevice, numpy):
 
 
 def test_noise_get_amplitudes_at_frequency_ranges(sounddevice, numpy):
-    # Ippity zippidy what is this farce
-    # a curious function that makes my tests pass?
-    force_reimport('enviroplus.noise')
     from enviroplus.noise import Noise
 
     noise = Noise(sample_rate=16000, duration=0.1)
@@ -49,10 +21,9 @@ def test_noise_get_amplitudes_at_frequency_ranges(sounddevice, numpy):
 
 
 def test_noise_get_noise_profile(sounddevice, numpy):
-    # Ippity zippidy what is this farce
-    # a curious function that makes my tests pass?
-    force_reimport('enviroplus.noise')
     from enviroplus.noise import Noise
+
+    numpy.mean.return_value = 10.0
 
     noise = Noise(sample_rate=16000, duration=0.1)
     amp_low, amp_mid, amp_high, amp_total = noise.get_noise_profile(
@@ -63,11 +34,10 @@ def test_noise_get_noise_profile(sounddevice, numpy):
 
     sounddevice.rec.assert_called_with(0.1 * 16000, samplerate=16000, blocking=True, channels=1, dtype='float64')
 
+    assert amp_total == 10.0
+
 
 def test_get_amplitude_at_frequency_range(sounddevice, numpy):
-    # Ippity zippidy what is this farce
-    # a curious function that makes my tests pass?
-    force_reimport('enviroplus.noise')
     from enviroplus.noise import Noise
 
     noise = Noise(sample_rate=16000, duration=0.1)

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -1,29 +1,3 @@
-import sys
-import mock
-
-
-def force_reimport(module):
-    """Force the module under test to be re-imported.
-
-    Because pytest runs all tests within the same scope (this makes me cry)
-    we have to do some manual housekeeping to avoid tests polluting each other.
-
-    Since conftest.py already does some sys.modules mangling I see no reason not to
-    do the same thing here.
-    """
-    if "." in module:
-        steps = module.split(".")
-    else:
-        steps = [module]
-    
-    for i in range(len(steps)):
-        module = ".".join(steps[0:i + 1])
-        try:
-            del sys.modules[module]
-        except KeyError:
-            pass
-
-
 def test_gas_setup(GPIO, smbus):
     from enviroplus import gas
     gas._is_setup = False
@@ -85,7 +59,6 @@ def test_gas_read_adc_str(GPIO, smbus):
 
 
 def test_gas_cleanup(GPIO, smbus):
-    force_reimport('enviroplus.gas')
     from enviroplus import gas
 
     gas.cleanup()


### PR DESCRIPTION
Add a simple check for #61 regression and fixed the bug.

Additionally dropped the `force_reimport` function in favour of an `autouse` fixture that forces module reimport.