### PR TITLE
Include python cffi in setup dependencies

### DIFF
--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -56,6 +56,7 @@ py2deps =
 	python-numpy
 	python-smbus
 	python-pil
+	python-cffi
 	python-spidev
 	python-rpi.gpio
 	libportaudio2
@@ -64,6 +65,7 @@ py3deps =
 	python3-numpy
 	python3-smbus
 	python3-pil
+	python3-cffi
 	python3-spidev
 	python3-rpi.gpio
 	libportaudio2


### PR DESCRIPTION

I ran into Issue #63 on Raspberry Pi Zero W, with Raspbian Lite - the install script would fail, and none of the examples would run. 

Adding python-cffi and python3-cffi in the setup.cfg fixed it, and all the examples work now. 