### PR TITLE
Added Adafruit IO Integration w/ Local Enviro+ Display Script(s) 

### DIFF
--- a/examples/adafruit_io.py
+++ b/examples/adafruit_io.py
@@ -46,10 +46,6 @@ import time
 # import Adafruit Blinka
 import board
 import busio
-
-# import sensor libraries
-import adafruit_sgp30
-import adafruit_veml6070
 import adafruit_bme280
 
 # import Adafruit IO REST client
@@ -82,10 +78,10 @@ except RequestError: # if we don't, create and assign them.
     altitude_feed = aio.create_feed(Feed(name='altitude'))
 
 # Create busio I2C
-i2c = busio.I2C(board.SCL, board.SDA, frequency=100000)
+i2c = busio.I2C(board.SCL, board.SDA)
 
 # Create BME280 object.
-bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
+bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c, address=0x76)
 bme280.sea_level_pressure = 1013.25
 
 

--- a/examples/adafruit_io.py
+++ b/examples/adafruit_io.py
@@ -5,8 +5,9 @@ to regularly send enviro-data using my Pimoroni Enviro+ Pi-HAT to my AIO dashboa
 python program provided by Pimoroni to display all the values nicely on it's OLED display.
 
 I kept having conflicts every time I tried to incorporate AIO into their code, so I decided to use this base code
-along side it to resolve the conflicts. Just add both the 'weather-and-light.py' and this file to your /etc/rc.local
-boot file, and you will be able to see the values both locally as well as your Adafruit IO dashboard!
+along side it to resolve the conflicts. Just add both this file to your /etc/rc.local
+boot file, along with whatever oled display code from the examples folder (I prefer the temperature-and-light), and
+you will be able to see the values both locally as well as your Adafruit IO dashboard!
 
                                                                                           ~dedSyn4ps3
 
@@ -63,14 +64,14 @@ ADAFRUIT_IO_USERNAME = 'YOUR_AIO_USERNAME'
 # Create an instance of the REST client
 aio = Client(ADAFRUIT_IO_USERNAME, ADAFRUIT_IO_KEY)
 
-try: # if we already have the feeds, assign them.
+try: # Assign feeds if they already exist
 
     temperature_feed = aio.feeds('temperature')
     humidity_feed = aio.feeds('humidity')
     pressure_feed = aio.feeds('pressure')
     altitude_feed = aio.feeds('altitude')
 
-except RequestError: # if we don't, create and assign them.
+except RequestError: # In case they don't exist
 
     temperature_feed = aio.create_feed(Feed(name='temperature'))
     humidity_feed = aio.create_feed(Feed(name='humidity'))
@@ -78,11 +79,11 @@ except RequestError: # if we don't, create and assign them.
     altitude_feed = aio.create_feed(Feed(name='altitude'))
 
 # Create busio I2C
-i2c = busio.I2C(board.SCL, board.SDA)
+i2c = busio.I2C(board.SCL, board.SDA) # Removed baudrate declaration, if needed, assign rate appropriate for your device(s)
 
-# Create BME280 object.
-bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c, address=0x76)
-bme280.sea_level_pressure = 1013.25
+# Create BME280 object
+bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c, address=0x76) # Original Adafruit example did not explicitly state the address of the sensor, which is needed to properly function
+bme280.sea_level_pressure = 1023.50 # Sea level pressure here in Ohio
 
 
 while True:

--- a/examples/adafruit_io.py
+++ b/examples/adafruit_io.py
@@ -1,0 +1,118 @@
+"""
+This code comes directly from Adafruit's learning guide on building an environmental monitor
+either with a Raspberry Pi, or Feather. I wanted to see if I could use it, minus a few bits and bobs,
+to regularly send enviro-data using my Pimoroni Enviro+ Pi-HAT to my AIO dashboard all while running another
+python program provided by Pimoroni to display all the values nicely on it's OLED display.
+
+I kept having conflicts every time I tried to incorporate AIO into their code, so I decided to use this base code
+along side it to resolve the conflicts. Just add both the 'weather-and-light.py' and this file to your /etc/rc.local
+boot file, and you will be able to see the values both locally as well as your Adafruit IO dashboard!
+
+                                                                                          ~dedSyn4ps3
+
+"""
+
+"""
+'environmental_monitor.py'
+===============================================================================
+Example of sending I2C sensor data
+from multiple sensors to Adafruit IO.
+ 
+Tutorial Link: https://learn.adafruit.com/adafruit-io-air-quality-monitor
+ 
+Adafruit invests time and resources providing this open source code.
+Please support Adafruit and open source hardware by purchasing
+products from Adafruit!
+ 
+Author(s): Brent Rubell for Adafruit Industries
+Copyright (c) 2018 Adafruit Industries
+Licensed under the MIT license.
+All text above must be included in any redistribution.
+ 
+Dependencies:
+    - Adafruit_Blinka (CircuitPython, on Pi.)
+        (https://github.com/adafruit/Adafruit_Blinka)
+
+    - Adafruit_CircuitPython_BME280.
+        (https://github.com/adafruit/Adafruit_CircuitPython_BME280)
+"""
+
+
+#!/usr/bin/env python3
+
+# Import standard python modules
+import time
+
+# import Adafruit Blinka
+import board
+import busio
+
+# import sensor libraries
+import adafruit_sgp30
+import adafruit_veml6070
+import adafruit_bme280
+
+# import Adafruit IO REST client
+from Adafruit_IO import Client, Feed, RequestError
+
+# Set to your Adafruit IO key.
+# Remember, your key is a secret,
+# so make sure not to publish it when you publish this code!
+ADAFRUIT_IO_KEY = 'YOUR_AIO_KEY'
+
+# Set to your Adafruit IO username.
+# (go to https://accounts.adafruit.com to find your username)
+ADAFRUIT_IO_USERNAME = 'YOUR_AIO_USERNAME'
+
+# Create an instance of the REST client
+aio = Client(ADAFRUIT_IO_USERNAME, ADAFRUIT_IO_KEY)
+
+try: # if we already have the feeds, assign them.
+
+    temperature_feed = aio.feeds('temperature')
+    humidity_feed = aio.feeds('humidity')
+    pressure_feed = aio.feeds('pressure')
+    altitude_feed = aio.feeds('altitude')
+
+except RequestError: # if we don't, create and assign them.
+
+    temperature_feed = aio.create_feed(Feed(name='temperature'))
+    humidity_feed = aio.create_feed(Feed(name='humidity'))
+    pressure_feed = aio.create_feed(Feed(name='pressure'))
+    altitude_feed = aio.create_feed(Feed(name='altitude'))
+
+# Create busio I2C
+i2c = busio.I2C(board.SCL, board.SDA, frequency=100000)
+
+# Create BME280 object.
+bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
+bme280.sea_level_pressure = 1013.25
+
+
+while True:
+
+    try:
+
+        # Read BME280
+        temp_data = bme280.temperature
+        temp_data = int(temp_data) * 1.8 + 22          #The 22 is just a slight correction to offset heat dissipation from the pi's hardware
+        humid_data = bme280.humidity
+        pressure_data = bme280.pressure
+        alt_data = bme280.altitude
+
+        # Send BME280 Data
+        
+        aio.send(temperature_feed.key, temp_data)
+        aio.send(humidity_feed.key, int(humid_data))
+
+        time.sleep(2)
+        
+        aio.send(pressure_feed.key, int(pressure_data))
+        aio.send(altitude_feed.key, int(alt_data))
+
+        # Avoid timeout from aio
+        time.sleep(30)
+
+    except Exception:
+
+        break

--- a/examples/weather-and-light.py
+++ b/examples/weather-and-light.py
@@ -303,8 +303,8 @@ WIDTH = disp.width
 HEIGHT = disp.height
 
 # The city and timezone that you want to display.
-city_name = "Sheffield"
-time_zone = "Europe/London"
+city_name = "Columbus"
+time_zone = "US/New_York"
 
 # Values that alter the look of the background
 blur = 50

--- a/examples/weather-and-light.py
+++ b/examples/weather-and-light.py
@@ -304,7 +304,7 @@ HEIGHT = disp.height
 
 # The city and timezone that you want to display.
 city_name = "Columbus"
-time_zone = "US/New_York"
+time_zone = "US/Eastern"
 
 # Values that alter the look of the background
 blur = 50
@@ -366,6 +366,7 @@ while True:
     cpu_temps = cpu_temps[1:] + [cpu_temp]
     avg_cpu_temp = sum(cpu_temps) / float(len(cpu_temps))
     corr_temperature = temperature - ((avg_cpu_temp - temperature) / factor)
+    corr_temperature_f = corr_temperature * 1.8 + 32
 
     if time_elapsed > 30:
         if min_temp is not None and max_temp is not None:
@@ -377,7 +378,7 @@ while True:
             min_temp = corr_temperature
             max_temp = corr_temperature
 
-    temp_string = f"{corr_temperature:.0f}°C"
+    temp_string = f"{corr_temperature_f:.0f}°F"
     img = overlay_text(img, (68, 18), temp_string, font_lg, align_right=True)
     spacing = font_lg.getsize(temp_string)[1] + 1
     if min_temp is not None and max_temp is not None:

--- a/examples/weather-and-light.py
+++ b/examples/weather-and-light.py
@@ -371,12 +371,12 @@ while True:
     if time_elapsed > 30:
         if min_temp is not None and max_temp is not None:
             if corr_temperature < min_temp:
-                min_temp = corr_temperature
+                min_temp = corr_temperature_f
             elif corr_temperature > max_temp:
-                max_temp = corr_temperature
+                max_temp = corr_temperature_f
         else:
-            min_temp = corr_temperature
-            max_temp = corr_temperature
+            min_temp = corr_temperature_f
+            max_temp = corr_temperature_f
 
     temp_string = f"{corr_temperature_f:.0f}°F"
     img = overlay_text(img, (68, 18), temp_string, font_lg, align_right=True)


### PR DESCRIPTION
I wanted to create a script to allow both the OLED display scripts to run and provide **awesome** local displays that they do, while at the same time sending the data to your Adafruit IO dashboard. I think that many Enviro(+) users would like an example to publish sensor data without having to scour other learning documentation just to figure it out :)