### PR TITLE
Correcting examples

### DIFF
--- a/examples/all-in-one.py
+++ b/examples/all-in-one.py
@@ -198,7 +198,7 @@ try:
             try:
                 data = pms5003.read()
             except pmsReadTimeoutError:
-                logging.warn("Failed to read PMS5003")
+                logging.warning("Failed to read PMS5003")
             else:
                 data = float(data.pm_ug_per_m3(1.0))
                 display_text(variables[mode], data, unit)
@@ -209,7 +209,7 @@ try:
             try:
                 data = pms5003.read()
             except pmsReadTimeoutError:
-                logging.warn("Failed to read PMS5003")
+                logging.warning("Failed to read PMS5003")
             else:
                 data = float(data.pm_ug_per_m3(2.5))
                 display_text(variables[mode], data, unit)
@@ -220,7 +220,7 @@ try:
             try:
                 data = pms5003.read()
             except pmsReadTimeoutError:
-                logging.warn("Failed to read PMS5003")
+                logging.warning("Failed to read PMS5003")
             else:
                 data = float(data.pm_ug_per_m3(10))
                 display_text(variables[mode], data, unit)

--- a/examples/combined.py
+++ b/examples/combined.py
@@ -12,7 +12,7 @@ except ImportError:
     import ltr559
 
 from bme280 import BME280
-from pms5003 import PMS5003, ReadTimeoutError as pmsReadTimeoutError
+from pms5003 import PMS5003, ReadTimeoutError as pmsReadTimeoutError, SerialTimeoutError
 from enviroplus import gas
 from subprocess import PIPE, Popen
 from PIL import Image
@@ -276,7 +276,7 @@ def main():
                 try:
                     data = pms5003.read()
                 except pmsReadTimeoutError:
-                    logging.warn("Failed to read PMS5003")
+                    logging.warning("Failed to read PMS5003")
                 else:
                     data = float(data.pm_ug_per_m3(1.0))
                     display_text(variables[mode], data, unit)
@@ -287,7 +287,7 @@ def main():
                 try:
                     data = pms5003.read()
                 except pmsReadTimeoutError:
-                    logging.warn("Failed to read PMS5003")
+                    logging.warning("Failed to read PMS5003")
                 else:
                     data = float(data.pm_ug_per_m3(2.5))
                     display_text(variables[mode], data, unit)
@@ -298,7 +298,7 @@ def main():
                 try:
                     data = pms5003.read()
                 except pmsReadTimeoutError:
-                    logging.warn("Failed to read PMS5003")
+                    logging.warning("Failed to read PMS5003")
                 else:
                     data = float(data.pm_ug_per_m3(10))
                     display_text(variables[mode], data, unit)
@@ -331,8 +331,8 @@ def main():
                 pms_data = None
                 try:
                     pms_data = pms5003.read()
-                except pmsReadTimeoutError:
-                    logging.warn("Failed to read PMS5003")
+                except (SerialTimeoutError, pmsReadTimeoutError):
+                    logging.warning("Failed to read PMS5003")
                 else:
                     save_data(7, float(pms_data.pm_ug_per_m3(1.0)))
                     save_data(8, float(pms_data.pm_ug_per_m3(2.5)))


### PR DESCRIPTION
Minor fixes to the examples. logging.warn() is deprecated. Also a timeout warning was not being caught in the event the particle sensor is not present.