### PR TITLE
Added user project: enviroplus_exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ sudo apt install python-numpy python-smbus python-pil python-setuptools
 * enviro monitor - https://github.com/roscoe81/enviro-monitor
 * mqtt-all - https://github.com/robmarkcole/rpi-enviro-mqtt - now upstream: [see examples/mqtt-all.py](examples/mqtt-all.py)
 * adafruit_io.py - https://github.com/dedSyn4ps3/enviroplus-python/blob/master/examples/adafruit_io.py - uses Adafruit Blinka and BME280 libraries to publish to Adafruit IO
+* enviroplus_exporter - https://github.com/tijmenvandenbrink/enviroplus_exporter - Prometheus exporter (with added support for Luftdaten and InfluxDB Cloud)
 
 ## Help & Support
 


### PR DESCRIPTION
Would like to add the enviroplus_exporter to the user projects section. The enviroplus_exporter is a Prometheus exporter and exposes the enviroplus metrics so they can be scraped with Prometheus.