### PR TITLE
Use configparser from backports to eliminate configparser bug

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -93,8 +93,8 @@ user_check
 apt_pkg_install python-configparser
 
 CONFIG_VARS=`python - <<EOF
-from configparser import ConfigParser
-c = ConfigParser()
+from backports import configparser
+c = configparser.ConfigParser()
 c.read('library/setup.cfg')
 p = dict(c['pimoroni'])
 # Convert multi-line config entries into bash arrays


### PR DESCRIPTION
Use https://pypi.org/project/configparser/ to fix issue with built in python2 configparser.
https://bugs.launchpad.net/ubuntu/+source/configparser/+bug/1821247