### PR TITLE
Pin to sounddevice 0.3.x, 0.4.x drops Python 2 support

### DIFF
--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
 	font-roboto
 	astral
 	pytz
-	sounddevice
+	sounddevice>=0.3.15,<0.4.0
 	paho-mqtt
 
 [flake8]


### PR DESCRIPTION
This should fix the issue reported in pimoroni/get#209 - it looks like Python 2.x support has been dropped from sounddevice 0.4.x but pip will still happily install the source package for Python 2.x and break horribly with syntax errors.