### PR TITLE
Adding Settings for TLS and Username/Password to MQTT Example

### DIFF
--- a/examples/mqtt-all.py
+++ b/examples/mqtt-all.py
@@ -8,6 +8,7 @@ Example run: python3 mqtt-all.py --broker 192.168.1.164 --topic enviro --usernam
 import argparse
 import ST7735
 import time
+import ssl
 from bme280 import BME280
 from pms5003 import PMS5003, ReadTimeoutError, SerialTimeoutError
 from enviroplus import gas
@@ -38,6 +39,9 @@ DEFAULT_MQTT_BROKER_IP = "localhost"
 DEFAULT_MQTT_BROKER_PORT = 1883
 DEFAULT_MQTT_TOPIC = "enviroplus"
 DEFAULT_READ_INTERVAL = 5
+DEFAULT_TLS_MODE = False
+DEFAULT_USERNAME = None
+DEFAULT_PASSWORD = None
 
 # mqtt callbacks
 def on_connect(client, userdata, flags, rc):
@@ -166,18 +170,23 @@ def main():
         help="the read interval in seconds",
     )
     parser.add_argument(
+        "--tls",
+        default=DEFAULT_TLS_MODE,
+        type=bool,
+        help="enable TLS"
+    )
+    parser.add_argument(
         "--username",
-        default=None,
+        default=DEFAULT_USERNAME,
         type=str,
-        help="mqtt username",
+        help="mqtt username"
     )
     parser.add_argument(
         "--password",
-        default=None,
+        default=DEFAULT_PASSWORD,
         type=str,
-        help="mqtt password",
+        help="mqtt password"
     )
-
     args = parser.parse_args()
 
     # Raspberry Pi ID
@@ -191,6 +200,7 @@ def main():
     client_id: {device_id}
     port: {args.port}
     topic: {args.topic}
+    tls: {args.tls}
     username: {args.username}
     password: {args.password}
 
@@ -204,6 +214,13 @@ def main():
         mqtt_client.username_pw_set(args.username, args.password)
     mqtt_client.on_connect = on_connect
     mqtt_client.on_publish = on_publish
+
+    if args.tls is True:
+        mqtt_client.tls_set(tls_version=ssl.PROTOCOL_TLSv1_2)
+
+    if args.username is not None:
+        mqtt_client.username_pw_set(args.username, password=args.password)
+
     mqtt_client.connect(args.broker, port=args.port)
 
     bus = SMBus(1)

--- a/examples/mqtt-all.py
+++ b/examples/mqtt-all.py
@@ -172,7 +172,7 @@ def main():
     parser.add_argument(
         "--tls",
         default=DEFAULT_TLS_MODE,
-        type=bool,
+        action='store_true',
         help="enable TLS"
     )
     parser.add_argument(


### PR DESCRIPTION
The `mqtt-all.py` example is really well put together. I've added the settings that enable TLS and Username / Password in case people would like to use this with their secure MQTT Brokers.
Example:
`python3 mqtt-all.py --broker localhost --port 8883 --topic enviro --tls --username enviropi --password raspberry`
