### PR TITLE
Add support for ADS1115

### DIFF
--- a/library/enviroplus/gas.py
+++ b/library/enviroplus/gas.py
@@ -41,15 +41,19 @@ ADC: {adc:05.02f} Volts
 
 
 def setup():
-    global adc, _is_setup
+    global adc, adc_type, _is_setup
     if _is_setup:
         return
     _is_setup = True
 
     adc = ads1015.ADS1015(i2c_addr=0x49)
+    adc_type = adc.detect_chip_type()
     adc.set_mode('single')
     adc.set_programmable_gain(MICS6814_GAIN)
-    adc.set_sample_rate(1600)
+    if adc_type == 'ADS1115':
+        adc.set_sample_rate(128)
+    else:
+        adc.set_sample_rate(1600)
 
     GPIO.setwarnings(False)
     GPIO.setmode(GPIO.BCM)

--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	pms5003
 	ltr559
 	st7735
-	ads1015
+	ads1015 >= 0.0.7
 	fonts
 	font-roboto
 	astral


### PR DESCRIPTION
Use the auto-detect feature of the ADS1015 library to support reading the gas sensor via an ADS1115.