### PR TITLE
Fix audio capture for #91

### DIFF
--- a/library/enviroplus/noise.py
+++ b/library/enviroplus/noise.py
@@ -83,6 +83,7 @@ class Noise():
     def _record(self):
         return sounddevice.rec(
             int(self.duration * self.sample_rate),
+            device='adau7002',
             samplerate=self.sample_rate,
             blocking=True,
             channels=1,

--- a/library/tests/test_noise.py
+++ b/library/tests/test_noise.py
@@ -17,7 +17,7 @@ def test_noise_get_amplitudes_at_frequency_ranges(sounddevice, numpy):
         (501, 1000)
     ])
 
-    sounddevice.rec.assert_called_with(0.1 * 16000, samplerate=16000, blocking=True, channels=1, dtype='float64')
+    sounddevice.rec.assert_called_with(0.1 * 16000, device='adau7002', samplerate=16000, blocking=True, channels=1, dtype='float64')
 
 
 def test_noise_get_noise_profile(sounddevice, numpy):
@@ -32,7 +32,7 @@ def test_noise_get_noise_profile(sounddevice, numpy):
         mid=0.36,
         high=None)
 
-    sounddevice.rec.assert_called_with(0.1 * 16000, samplerate=16000, blocking=True, channels=1, dtype='float64')
+    sounddevice.rec.assert_called_with(0.1 * 16000, device='adau7002', samplerate=16000, blocking=True, channels=1, dtype='float64')
 
     assert amp_total == 10.0
 


### PR DESCRIPTION
Add the `ada7002` device into the `sounddevice.rec` startup, to avoid trying to record from whatever the default happens to be and failing miserably. (Pulse Audio??)