### PR TITLE
mqtt-all.py example: use retained publications

### DIFF
--- a/examples/mqtt-all.py
+++ b/examples/mqtt-all.py
@@ -262,7 +262,7 @@ def main():
                 values.update(pms_values)
             values["serial"] = device_serial_number
             print(values)
-            mqtt_client.publish(args.topic, json.dumps(values))
+            mqtt_client.publish(args.topic, json.dumps(values), retain=True)
             display_status(disp, args.broker)
             time.sleep(args.interval)
         except Exception as e:


### PR DESCRIPTION
Per [the change I suggested to the Pico-based Enviro code](https://github.com/pimoroni/enviro/pull/2), with this change, the MQTT messages will be published with the retain flag set, so that if a consumer is not subscribed, the most recent set of readings can still be read by a future subscriber later. 

This supports the [homebridge-enviroplus plugin](https://github.com/mhawkshaw/homebridge-enviroplus/issues/2#issuecomment-1215872947) better, so that a publication is more likely to exist on the topic even if the Pi with Enviroplus / this example code is not running at the time. 

Additional update to consider would be to align the message data formats between this sample and the newer Enviro product line.