### PR TITLE
examples: add shebang

### DIFF
--- a/examples/noise-amps-at-freqs.py
+++ b/examples/noise-amps-at-freqs.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import st7735
 from PIL import Image, ImageDraw
 

--- a/examples/noise-profile.py
+++ b/examples/noise-profile.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import st7735
 from PIL import Image, ImageDraw
 

--- a/examples/sensorcommunity_combined.py
+++ b/examples/sensorcommunity_combined.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import colorsys
 import logging
 import time


### PR DESCRIPTION
This add missing shebang. It will avoid some error for users launching script without specifying python3 interpreter (`./` only).