### PR TITLE
Misc boilerplate updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ endif
 	@echo "deploy:       build and upload to PyPi"
 	@echo "tag:          tag the repository with the current version\n"
 
+version:
+	@hatch version
+
 install:
 	./install.sh --unstable
 
@@ -47,7 +50,7 @@ pytest:
 nopost:
 	@bash check.sh --nopost
 
-tag:
+tag: version
 	git tag -a "v${LIBRARY_VERSION}" -m "Version ${LIBRARY_VERSION}"
 
 build: check

--- a/install.sh
+++ b/install.sh
@@ -58,11 +58,6 @@ find_config() {
 		if [ ! -f "$CONFIG_DIR/$CONFIG_FILE" ]; then
 			fatal "Could not find $CONFIG_FILE!"
 		fi
-	else
-		if [ -f "/boot/$CONFIG_FILE" ] && [ ! -L "/boot/$CONFIG_FILE" ]; then
-			warning "Oops! It looks like /boot/$CONFIG_FILE is not a link to $CONFIG_DIR/$CONFIG_FILE"
-			warning "You might want to fix this!"
-		fi
 	fi
 	inform "Using $CONFIG_FILE in $CONFIG_DIR"
 }
@@ -168,6 +163,12 @@ function apt_pkg_install {
 function pip_pkg_install {
 	# A null Keyring prevents pip stalling in the background
 	PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring $PYTHON -m pip install --upgrade "$@"
+	check_for_error
+}
+
+function pip_requirements_install {
+	# A null Keyring prevents pip stalling in the background
+	PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring $PYTHON -m pip install -r "$@"
 	check_for_error
 }
 
@@ -335,6 +336,15 @@ if [ -d "examples" ]; then
 		cp -r examples/ "$RESOURCES_DIR"
 		echo "rm -r $RESOURCES_DIR" >> "$UNINSTALLER"
 		success "Done!"
+	fi
+fi
+
+printf "\n"
+
+if [ -f "requirements-examples.txt" ]; then
+	if confirm "Would you like to install example dependencies?"; then
+		inform "Installing dependencies from requirements-examples.txt..."
+		pip_requirements_install requirements-examples.txt
 	fi
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,7 @@ dependencies = [
     "pms5003 >= 1.0.1",
     "ltr559 >= 1.0.0",
     "st7735 >= 1.0.0",
-    "ads1015 >= 1.0.0",
-    "fonts",
-    "font-roboto",
-    "astral",
-    "pytz",
-    "sounddevice",
-    "paho-mqtt"
+    "ads1015 >= 1.0.0"
 ]
 
 [project.urls]

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -4,4 +4,4 @@ astral
 pytz
 sounddevice
 paho-mqtt
-
+pillow

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -1,0 +1,7 @@
+fonts
+font-roboto
+astral
+pytz
+sounddevice
+paho-mqtt
+

--- a/tox.ini
+++ b/tox.ini
@@ -20,15 +20,8 @@ commands =
 	python -m build --no-isolation
 	python -m twine check dist/*
 	isort --check .
-	ruff .
+	ruff check .
 	codespell .
 deps =
-	check-manifest
-	ruff
-	codespell
-	isort
-	twine
-	build
-	hatch
-	hatch-fancy-pypi-readme
+	-r{toxinidir}/requirements-dev.txt
 


### PR DESCRIPTION
1. Sync with latest boilerplate (no longer complains about /boot/config.txt)
2. Move example requirements to `requirements-examples.txt` (needs a library bump so it doesn't pull in ALL THE THINGS)
3. Add `pillow` to example requirements